### PR TITLE
New commands and signals

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,9 +1,10 @@
 #require "lwt.unix";;
-#require "lwt.ppx";;
+#require "lwt_ppx";;
 #require "stdint";;
 #require "yojson";;
 #require "ppx_deriving_yojson";;
 #require "ppx_deriving.show";;
-#require "rresult";;
-#directory "_build/src";;
+#require "result";;
+#directory "_build/default/src";;
+#directory "_build/default/src/.i3ipc.objs/byte";;
 #load "i3ipc.cmo";;

--- a/examples/i3_msg.ml
+++ b/examples/i3_msg.ml
@@ -63,6 +63,9 @@ let main =
   | "get_binding_modes" ->
     let%lwt binding_modes = I3ipc.get_binding_modes conn in
     I3ipc.Reply.pp_binding_modes fmt binding_modes |> Lwt.return
+  | "get_config" ->
+    let%lwt config = I3ipc.get_config conn in
+    I3ipc.Reply.pp_config fmt config |> Lwt.return
   | _ -> Format.fprintf Format.err_formatter "Unsupported message type"; exit 1
 
 let () = Lwt_main.run main

--- a/examples/i3_msg.ml
+++ b/examples/i3_msg.ml
@@ -60,6 +60,9 @@ let main =
   | "get_version" ->
     let%lwt version = I3ipc.get_version conn in
     I3ipc.Reply.pp_version fmt version |> Lwt.return
+  | "get_binding_modes" ->
+    let%lwt binding_modes = I3ipc.get_binding_modes conn in
+    I3ipc.Reply.pp_binding_modes fmt binding_modes |> Lwt.return
   | _ -> Format.fprintf Format.err_formatter "Unsupported message type"; exit 1
 
 let () = Lwt_main.run main

--- a/examples/i3_msg.ml
+++ b/examples/i3_msg.ml
@@ -66,6 +66,9 @@ let main =
   | "get_config" ->
     let%lwt config = I3ipc.get_config conn in
     I3ipc.Reply.pp_config fmt config |> Lwt.return
+  | "send_tick" ->
+    let%lwt tick = I3ipc.send_tick conn payload in
+    I3ipc.Reply.pp_tick fmt tick |> Lwt.return
   | _ -> Format.fprintf Format.err_formatter "Unsupported message type"; exit 1
 
 let () = Lwt_main.run main

--- a/examples/i3_msg.ml
+++ b/examples/i3_msg.ml
@@ -68,7 +68,7 @@ let main =
     I3ipc.Reply.pp_config fmt config |> Lwt.return
   | "send_tick" ->
     let%lwt tick = I3ipc.send_tick conn payload in
-    I3ipc.Reply.pp_tick fmt tick |> Lwt.return
+    Format.pp_print_bool fmt tick |> Lwt.return
   | _ -> Format.fprintf Format.err_formatter "Unsupported message type"; exit 1
 
 let () = Lwt_main.run main

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -17,21 +17,6 @@ type protocol_error =
 
 exception Protocol_error of protocol_error
 
-module Uint64 = struct
-  include Uint64
-
-  let of_yojson (u_j : Yojson.Safe.json) =
-    match u_j with
-    | `Int i -> Result.Ok (Uint64.of_int i)
-    | `Intlit s -> begin
-      try Result.Ok (Uint64.of_string s)
-      with Invalid_argument e -> Result.Error e
-    end
-    | _ -> Result.Error ("not an integer literal: "^(Yojson.Safe.to_string u_j))
-
-  let pp fmt ui = Format.pp_print_string fmt (to_string ui)
-end
-
 (******************************************************************************)
 
 module Reply = struct

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -259,6 +259,13 @@ module Reply = struct
 
   let pp_config fmt config =
     Format.pp_print_string fmt config.config
+
+  type tick = {
+    tick_success : bool [@key "success"]
+  } [@@deriving of_yojson, show]
+
+  let pp_tick fmt tick =
+    Format.pp_print_bool fmt tick
 end
 
 (******************************************************************************)
@@ -509,6 +516,7 @@ let bar_config_ty = Uint32.of_int 6
 let version_ty = Uint32.of_int 7
 let binding_modes_ty = Uint32.of_int 8
 let config_ty = Uint32.of_int 9
+let send_tick_ty = Uint32.of_int 10
 
 let ignore_error = function
   | Result.Ok x -> x
@@ -584,6 +592,14 @@ let get_config conn =
   handle_reply
     (send_cmd_with_ty conn config_ty "")
     Reply.config_of_yojson
+
+let send_tick conn payload =
+  let%lwt protocol_reply = 
+    handle_reply
+      (send_cmd_with_ty conn send_tick_ty payload)
+      Reply.tick_of_yojson in
+  Lwt.return protocol_reply.Reply.tick_success
+
 (******************************************************************************)
 
 type subscription =

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -258,7 +258,7 @@ module Reply = struct
   } [@@deriving of_yojson, show]
 
   let pp_config fmt config =
-    Format.pp_print_string fmt config.config
+    Format.pp_print_string fmt config
 
   type tick = {
     tick_success : bool [@key "success"]
@@ -589,9 +589,11 @@ let get_binding_modes conn =
     Reply.binding_modes_of_yojson
 
 let get_config conn =
-  handle_reply
-    (send_cmd_with_ty conn config_ty "")
-    Reply.config_of_yojson
+  let%lwt protocol_reply =
+    handle_reply
+      (send_cmd_with_ty conn config_ty "")
+      Reply.config_of_yojson in
+  Lwt.return protocol_reply.Reply.config
 
 let send_tick conn payload =
   let%lwt protocol_reply = 

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -17,6 +17,21 @@ type protocol_error =
 
 exception Protocol_error of protocol_error
 
+module Uint64 = struct
+  include Uint64
+
+  let of_yojson (u_j : Yojson.Safe.json) =
+    match u_j with
+    | `Int i -> Result.Ok (Uint64.of_int i)
+    | `Intlit s -> begin
+      try Result.Ok (Uint64.of_string s)
+      with Invalid_argument e -> Result.Error e
+    end
+    | _ -> Result.Error ("not an integer literal: "^(Yojson.Safe.to_string u_j))
+
+  let pp fmt ui = Format.pp_print_string fmt (to_string ui)
+end
+
 (******************************************************************************)
 
 module Reply = struct
@@ -121,7 +136,7 @@ module Reply = struct
   type node = {
     nodes : (node list [@default []]);
     floating_nodes: (node list [@default []]);
-    id: int32;
+    id: Uint64.t;
     name: string option;
     nodetype: node_type [@key "type"];
     border: node_border;

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -249,6 +249,9 @@ module Reply = struct
 
   let result_of_command_outcome { success; error } =
     if success then Result.Ok () else Result.Error (error |? "")
+
+  type binding_modes = string list
+    [@@deriving of_yojson, show]
 end
 
 (******************************************************************************)
@@ -564,6 +567,10 @@ let get_version conn =
     (send_cmd_with_ty conn version_ty "")
     Reply.version_of_yojson
 
+let get_binding_modes conn =
+  handle_reply
+    (send_cmd_with_ty conn binding_modes_ty "")
+    Reply.binding_modes_of_yojson
 (******************************************************************************)
 
 type subscription =

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -52,6 +52,7 @@ module Reply = struct
   type output = {
     name: string;
     active: bool;
+    primary: bool;
     current_workspace: string option;
     rect: rect;
   } [@@deriving of_yojson { strict = false }, show]
@@ -109,8 +110,17 @@ module Reply = struct
     | `String s -> Result.Ok (Unknown s)
     | j -> Result.Error ("Reply.node_layout_of_yojson: " ^ Json.to_string j)
 
+  type window_properties = {
+    class_: string option [@key "class"];
+    instance: string option;
+    title: string option;
+    transient_for: string option;
+    window_role: string option [@default None];
+  } [@@deriving of_yojson { strict = false }, show]
+
   type node = {
     nodes : (node list [@default []]);
+    floating_nodes: (node list [@default []]);
     id: int32;
     name: string option;
     nodetype: node_type [@key "type"];
@@ -123,8 +133,10 @@ module Reply = struct
     deco_rect: rect;
     geometry: rect;
     window: int option;
+    window_properties: window_properties option [@default None];
     urgent: bool;
     focused: bool;
+    focus: int32 list;
   } [@@deriving of_yojson { strict = false }, show]
 
   type mark = string [@@deriving yojson, show]

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -133,6 +133,7 @@ module Reply = struct
     floating_nodes: (node list [@default []]);
     id: id;
     name: string option;
+    num: int option [@default None];
     nodetype: node_type [@key "type"];
     border: node_border;
     current_border_width: int;

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -133,10 +133,20 @@ module Reply = struct
     window_role: string option [@default None];
   } [@@deriving of_yojson { strict = false }, show]
 
+  type id = string
+
+  let id_of_yojson id_j =
+    match id_j with
+    | `Int i -> Result.Ok (string_of_int i)
+    | `Intlit s -> Result.Ok s
+    | _ -> Result.Error ("not an integer literal: "^(Yojson.Safe.to_string id_j))
+
+  let pp_id fmt i = Format.pp_print_string fmt i
+
   type node = {
     nodes : (node list [@default []]);
     floating_nodes: (node list [@default []]);
-    id: Uint64.t;
+    id: id;
     name: string option;
     nodetype: node_type [@key "type"];
     border: node_border;

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -382,6 +382,11 @@ module Event = struct
     change : string
   } [@@deriving of_yojson, show]
 
+  type tick_event_info = {
+    first : bool;
+    payload : string
+  } [@@deriving of_yojson, show]
+
   type t =
     | Workspace of workspace_event_info
     | Output of output_event_info
@@ -390,6 +395,7 @@ module Event = struct
     | BarConfig of bar_config_event_info
     | Binding of binding_event_info
     | Shutdown of shutdown_reason
+    | Tick of tick_event_info
   [@@deriving show]
 
   let unfold_shut_info sev =
@@ -625,6 +631,7 @@ type subscription =
   | BarConfig
   | Binding
   | Shutdown
+  | Tick
 
 let subscription_to_yojson = function
   | Workspace -> `String "workspace"
@@ -634,6 +641,7 @@ let subscription_to_yojson = function
   | BarConfig -> `String "barconfig_update"
   | Binding -> `String "binding"
   | Shutdown -> `String "shutdown"
+  | Tick -> `String "tick"
 
 type subscription_list =
   subscription list [@@deriving to_yojson]
@@ -665,6 +673,7 @@ let event_of_raw_event (ty, payload) =
     | "exit" -> Exit
     | v -> raise (Protocol_error (Bad_reply v))
   )
+  | 7 -> Event.Tick (Event.tick_event_info_of_yojson j |> ignore_error)
   | _ -> raise (Protocol_error (Unknown_type ty))
 
 let next_event conn =

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -252,6 +252,13 @@ module Reply = struct
 
   type binding_modes = string list
     [@@deriving of_yojson, show]
+
+  type config = {
+    config : string
+  } [@@deriving of_yojson, show]
+
+  let pp_config fmt config =
+    Format.pp_print_string fmt config.config
 end
 
 (******************************************************************************)
@@ -501,6 +508,7 @@ let marks_ty = Uint32.of_int 5
 let bar_config_ty = Uint32.of_int 6
 let version_ty = Uint32.of_int 7
 let binding_modes_ty = Uint32.of_int 8
+let config_ty = Uint32.of_int 9
 
 let ignore_error = function
   | Result.Ok x -> x
@@ -571,6 +579,11 @@ let get_binding_modes conn =
   handle_reply
     (send_cmd_with_ty conn binding_modes_ty "")
     Reply.binding_modes_of_yojson
+
+let get_config conn =
+  handle_reply
+    (send_cmd_with_ty conn config_ty "")
+    Reply.config_of_yojson
 (******************************************************************************)
 
 type subscription =

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -79,6 +79,7 @@ module Reply : sig
     floating_nodes: node list;
     id: id;
     name: string option;
+    num: int option;
     nodetype: node_type;
     border: node_border;
     current_border_width: int;

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -72,10 +72,12 @@ module Reply : sig
     window_role: string option;
   }
 
+  type id = string
+
   type node = {
     nodes: node list;
     floating_nodes: node list;
-    id: Stdint.Uint64.t;
+    id: id;
     name: string option;
     nodetype: node_type;
     border: node_border;

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -37,6 +37,7 @@ module Reply : sig
   type output = {
     name: string;
     active: bool;
+    primary: bool;
     current_workspace: string option;
     rect: rect;
   }
@@ -63,8 +64,17 @@ module Reply : sig
     | Output
     | Unknown of string
 
+  type window_properties = {
+    class_: string option;
+    instance: string option;
+    title: string option;
+    transient_for: string option;
+    window_role: string option;
+  }
+
   type node = {
     nodes: node list;
+    floating_nodes: node list;
     id: int32;
     name: string option;
     nodetype: node_type;
@@ -77,8 +87,10 @@ module Reply : sig
     deco_rect: rect;
     geometry: rect;
     window: int option;
+    window_properties: window_properties option;
     urgent: bool;
     focused: bool;
+    focus: int32 list;
   }
 
   type mark = string

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -72,12 +72,12 @@ module Reply : sig
     window_role: string option;
   }
 
-  type id = string
+  type node_id = string
 
   type node = {
     nodes: node list;
     floating_nodes: node list;
-    id: id;
+    id: node_id;
     name: string option;
     num: int option;
     nodetype: node_type;
@@ -93,7 +93,7 @@ module Reply : sig
     window_properties: window_properties option;
     urgent: bool;
     focused: bool;
-    focus: int32 list;
+    focus: node_id list;
   }
 
   type mark = string
@@ -154,10 +154,6 @@ module Reply : sig
     config : string
   }
 
-  type tick = {
-    tick_success : bool
-  }
-
   (** {3 Pretty-printing} *)
 
   val pp_command_outcome : Format.formatter -> command_outcome -> unit
@@ -173,8 +169,7 @@ module Reply : sig
   val pp_bar_config : Format.formatter -> bar_config -> unit
   val pp_version : Format.formatter -> version -> unit
   val pp_binding_modes : Format.formatter -> binding_modes -> unit
-  val pp_config : Format.formatter -> string -> unit
-  val pp_tick : Format.formatter -> bool -> unit
+  val pp_config : Format.formatter -> config -> unit
 end
 
 (** Type definitions for the events that can be subscribed to. *)
@@ -375,7 +370,7 @@ val get_version : connection -> Reply.version Lwt.t
 val get_binding_modes : connection -> Reply.binding_modes Lwt.t
 
 (** Get the config file as loaded by i3 most recently. *)
-val get_config : connection -> string Lwt.t
+val get_config : connection -> Reply.config Lwt.t
 
 (** Sends a tick event with the specified payload. *)
 val send_tick : connection -> string -> bool Lwt.t

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -233,6 +233,11 @@ module Event : sig
     | Restart (** i3 is shutting down due to a restart requested by the user *)
     | Exit    (** i3 is shutting down due to an exit requested by the user *)
 
+  type tick_event_info = {
+    first : bool;
+    payload : string
+  }
+
   type t =
     | Workspace of workspace_event_info
     (** Sent when the user switches to a different workspace, when a new
@@ -269,7 +274,9 @@ module Event : sig
         your program survive an i3 restart, you must subscribe to this event and
         handle the subsequent exception. *)
 
-    (* | Tick TODO *)
+    | Tick of tick_event_info
+    (** This event is triggered by a subscription to tick events or by a
+        SEND_TICK message. *)
 
   (** {3 Pretty-printing} *)
 
@@ -286,6 +293,7 @@ module Event : sig
   val pp_binding : Format.formatter -> binding -> unit
   val pp_binding_event_info : Format.formatter -> binding_event_info -> unit
   val pp_shutdown_reason : Format.formatter -> shutdown_reason -> unit
+  val pp_tick_event_info : Format.formatter -> tick_event_info -> unit
   val pp : Format.formatter -> t -> unit
 end
 
@@ -310,6 +318,7 @@ type subscription =
   | BarConfig
   | Binding
   | Shutdown
+  | Tick
 
 (** Subscribe to certain events. *)
 val subscribe : connection -> subscription list -> Reply.command_outcome Lwt.t

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -133,6 +133,8 @@ module Reply : sig
     loaded_config_file_name: string;
   }
 
+  type binding_modes = string list
+
   (** {3 Pretty-printing} *)
 
   val pp_command_outcome : Format.formatter -> command_outcome -> unit
@@ -147,6 +149,7 @@ module Reply : sig
   val pp_bar_colors : Format.formatter -> bar_colors -> unit
   val pp_bar_config : Format.formatter -> bar_config -> unit
   val pp_version : Format.formatter -> version -> unit
+  val pp_binding_modes : Format.formatter -> binding_modes -> unit
 end
 
 (** Type definitions for the events that can be subscribed to. *)
@@ -297,3 +300,6 @@ val get_bar_config : connection -> Reply.bar_id -> Reply.bar_config Lwt.t
 
 (** Get the version of i3. *)
 val get_version : connection -> Reply.version Lwt.t
+
+(** Get binding modes of i3. *)
+val get_binding_modes : connection -> Reply.binding_modes Lwt.t

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -158,7 +158,7 @@ module Reply : sig
   val pp_bar_config : Format.formatter -> bar_config -> unit
   val pp_version : Format.formatter -> version -> unit
   val pp_binding_modes : Format.formatter -> binding_modes -> unit
-  val pp_config : Format.formatter -> config -> unit
+  val pp_config : Format.formatter -> string -> unit
   val pp_tick : Format.formatter -> bool -> unit
 end
 
@@ -315,7 +315,7 @@ val get_version : connection -> Reply.version Lwt.t
 val get_binding_modes : connection -> Reply.binding_modes Lwt.t
 
 (** Get the config file as loaded by i3 most recently. *)
-val get_config : connection -> Reply.config Lwt.t
+val get_config : connection -> string Lwt.t
 
 (** Sends a tick event with the specified payload. *)
 val send_tick : connection -> string -> bool Lwt.t

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -139,6 +139,10 @@ module Reply : sig
     config : string
   }
 
+  type tick = {
+    tick_success : bool
+  }
+
   (** {3 Pretty-printing} *)
 
   val pp_command_outcome : Format.formatter -> command_outcome -> unit
@@ -155,6 +159,7 @@ module Reply : sig
   val pp_version : Format.formatter -> version -> unit
   val pp_binding_modes : Format.formatter -> binding_modes -> unit
   val pp_config : Format.formatter -> config -> unit
+  val pp_tick : Format.formatter -> bool -> unit
 end
 
 (** Type definitions for the events that can be subscribed to. *)
@@ -311,3 +316,6 @@ val get_binding_modes : connection -> Reply.binding_modes Lwt.t
 
 (** Get the config file as loaded by i3 most recently. *)
 val get_config : connection -> Reply.config Lwt.t
+
+(** Sends a tick event with the specified payload. *)
+val send_tick : connection -> string -> bool Lwt.t

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -135,6 +135,10 @@ module Reply : sig
 
   type binding_modes = string list
 
+  type config = {
+    config : string
+  }
+
   (** {3 Pretty-printing} *)
 
   val pp_command_outcome : Format.formatter -> command_outcome -> unit
@@ -150,6 +154,7 @@ module Reply : sig
   val pp_bar_config : Format.formatter -> bar_config -> unit
   val pp_version : Format.formatter -> version -> unit
   val pp_binding_modes : Format.formatter -> binding_modes -> unit
+  val pp_config : Format.formatter -> config -> unit
 end
 
 (** Type definitions for the events that can be subscribed to. *)
@@ -303,3 +308,6 @@ val get_version : connection -> Reply.version Lwt.t
 
 (** Get binding modes of i3. *)
 val get_binding_modes : connection -> Reply.binding_modes Lwt.t
+
+(** Get the config file as loaded by i3 most recently. *)
+val get_config : connection -> Reply.config Lwt.t

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -75,7 +75,7 @@ module Reply : sig
   type node = {
     nodes: node list;
     floating_nodes: node list;
-    id: int32;
+    id: Stdint.Uint64.t;
     name: string option;
     nodetype: node_type;
     border: node_border;


### PR DESCRIPTION
In this bunch of commits you will find:
 * 3 missing commands: `GET_BINDING_MODES`, `GET_CONFIG` and `SEND_TICK`
 * get_config has a simplified interface: `val get_config : connection -> string Lwt.t`
 * you can subscribe to the `Shutdown` and `Tick` events
 * some documentation about what happens when i3 fires `SHUTDOWN`
 * a complete `GET_TREE` reply, I added the `primary` bool, `floating_nodes` and the complete structure of the `window_properties`
 * `.ocamlinit` up to date
 * Window ID type from `int32` to `string`