### PR TITLE
Fix: use I3SOCK environment variable if available

### DIFF
--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -426,9 +426,9 @@ type connection = {
 
 let connect () =
   try%lwt
-    let%lwt socketpath = match Sys.getenv_opt "I3SOCK" with
-      | None -> Lwt_process.pread ("i3", [|"i3"; "--get-socketpath"|])
-      | Some s -> Lwt.return s
+    let%lwt socketpath = match Sys.getenv "I3SOCK" with
+      | exception Not_found -> Lwt_process.pread ("i3", [|"i3"; "--get-socketpath"|])
+      | s -> Lwt.return s
     in
     let socketpath = String.trim socketpath in
     let fd = Lwt_unix.socket Lwt_unix.PF_UNIX Lwt_unix.SOCK_STREAM 0 in

--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -426,7 +426,10 @@ type connection = {
 
 let connect () =
   try%lwt
-    let%lwt socketpath = Lwt_process.pread ("i3", [|"i3"; "--get-socketpath"|]) in
+    let%lwt socketpath = match Sys.getenv_opt "I3SOCK" with
+      | None -> Lwt_process.pread ("i3", [|"i3"; "--get-socketpath"|])
+      | Some s -> Lwt.return s
+    in
     let socketpath = String.trim socketpath in
     let fd = Lwt_unix.socket Lwt_unix.PF_UNIX Lwt_unix.SOCK_STREAM 0 in
     let%lwt () = Lwt_unix.connect fd (Lwt_unix.ADDR_UNIX socketpath) in


### PR DESCRIPTION
This fix enables i3ipc to work with i3-compatible programs such as [Sway](/swaywm/sway)