### PR TITLE
Support for Sway node_border csd

### DIFF
--- a/src/i3ipc.ml
+++ b/src/i3ipc.ml
@@ -83,12 +83,14 @@ module Reply = struct
     | Border_normal
     | Border_none
     | Border_pixel
+    | Border_csd
   [@@deriving show]
 
   let node_border_of_yojson = function
     | `String "normal" -> Result.Ok Border_normal
     | `String "none" -> Result.Ok Border_none
     | `String "pixel" -> Result.Ok Border_pixel
+    | `String "csd" -> Result.Ok Border_csd
     | j -> Result.Error ("Reply.node_border_of_yojson: " ^ Json.to_string j)
 
   type node_layout =

--- a/src/i3ipc.mli
+++ b/src/i3ipc.mli
@@ -56,6 +56,7 @@ module Reply : sig
     | Border_normal
     | Border_none
     | Border_pixel
+    | Border_csd
 
   type node_layout =
     | SplitH


### PR DESCRIPTION
Sway has an additional border type, "csd", which causes bad replies. This PR fixes it

https://github.com/swaywm/sway/blob/master/sway/sway-ipc.7.scd